### PR TITLE
now the orientation is always 'white' when playing racingKings

### DIFF
--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -207,6 +207,9 @@ export const store = new Vuex.Store({
       state.destinations = payload
     },
     variant (state, payload) {
+      if (payload === 'racingkings') {
+        state.orientation = 'white'
+      }
       state.variant = payload
     },
     engineBinary (state, payload) {


### PR DESCRIPTION
# Purpose
now the orientation is always 'white' when playing racingKings

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
