### PR TITLE
added sounds when scrolling forward

### DIFF
--- a/src/renderer/components/GameBoards.vue
+++ b/src/renderer/components/GameBoards.vue
@@ -166,13 +166,16 @@ export default {
         return
       }
       if (num === -1) {
+        this.$store.dispatch('playAudio', this.moves[0].name)
         this.$store.dispatch('fen', this.moves[0].fen)
         return
       }
       if (num === 0) {
+        this.$store.dispatch('playAudio', this.moves[0].name)
         this.$store.dispatch('fen', this.moves[1].fen)
         return
       }
+      this.$store.dispatch('playAudio', this.moves[num + 1].name)
       this.$store.dispatch('fen', this.moves[num + 1].fen)
     },
     flipBoard () {

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -329,6 +329,9 @@ export const store = new Vuex.Store({
     }
   },
   actions: { // async
+    playAudio (context, payload) {
+      context.commit('playAudio', payload)
+    },
     curVar960Fen (context, payload) {
       context.commit('curVar960Fen', payload)
     },


### PR DESCRIPTION
# Purpose
Sounds where missing when moving forward by one in the move history, they are now added.

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
