### PR TITLE
added Atomic to the Variants 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 <img src="./media/screenshots/liground-0.0.1.png" alt="LiGround screenshot" title="LiGround screenshot." />
 
 ### Build Setup
-
 ``` bash
 # install dependencies
 npm install
@@ -21,13 +20,13 @@ npm run lint
 ```
 
 ### Post-Installation Actions
+LiGround ships with preincluded engine binaries. By default all engines are downloaded automatically into the `./engines/` folder as postinstall action. However, if no prebuilt binaries are available for you system or something goes wrong, please go ahead and build/download them manually:
 
-* [Download](https://github.com/ianfab/Fairy-Stockfish/releases/) a **largeboard** binary of _Fairy-Stockfish_ or build it from scratch.
-
-* Rename the _Fairy-Stockfish_ binary to `stockfish` and move it to `./engines/`.
+* Download [Stockfish 2020-06-13](https://github.com/niklasf/Stockfish/releases/fishnet-20200613) and rename it to `stockfish`
+* Download [Multi-Variant-Stockfish 10](https://github.com/ddugovic/Stockfish/releases/variant_sf_10) and rename it to `multi-variant-stockfish`
+* Download [Fairy-Stockfish 13 **Largeboard**](https://github.com/ianfab/Fairy-Stockfish/releases/fairy_sf_13) and rename it to `fairy-stockfish`
 
 ### Libraries
-
 The following libraries or assets are used in **LiGround**:
 
 Library | Description | Usage
@@ -40,7 +39,6 @@ Library | Description | Usage
 [**electron-vue**](https://github.com/SimulatedGREG/electron-vue) | An Electron & Vue.js quick start boilerplate | Used for the boilerplate code.
 
 ### Related
-
 Projects that influenced the creation of **LiGround**:
 
 Project | Description

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -99,6 +99,6 @@ downloadBinary('multi-variant-stockfish', {
 })
 
 downloadBinary('fairy-stockfish', {
-  linux: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_11_2/fairy-stockfish-largeboard_x86-64',
-  win: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_11_2/fairy-stockfish-largeboard_x86-64.exe'
+  linux: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64',
+  win: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64.exe'
 })

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -118,7 +118,7 @@ export const store = new Vuex.Store({
       '⛰️ King of the Hill': 'kingofthehill',
       '️Three-Check': '3check',
       Antichess: 'antichess',
-      'Atomic': 'atomic',
+      Atomic: 'atomic',
       Horde: 'horde',
       '🏇 Racing Kings': 'racingkings',
       Makruk: 'makruk',

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -118,6 +118,7 @@ export const store = new Vuex.Store({
       '⛰️ King of the Hill': 'kingofthehill',
       '️Three-Check': '3check',
       Antichess: 'antichess',
+      'Atomic': 'atomic',
       Horde: 'horde',
       '🏇 Racing Kings': 'racingkings',
       Makruk: 'makruk',
@@ -162,7 +163,7 @@ export const store = new Vuex.Store({
     selectedGame: null,
     boardStyle: 'blue',
     internationalVariants: [
-      'chess', 'crazyhouse', 'horde', 'kingofthehill', '3check', 'racingkings', 'antichess'
+      'chess', 'crazyhouse', 'horde', 'kingofthehill', '3check', 'racingkings', 'antichess', 'atomic'
     ],
     seaVariants: [
       'makruk'


### PR DESCRIPTION
# Purpose
Added Variant Atomic

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [ ] In Crazyhouse the pocket pieces are shown and you can drop pieces
