### PR TITLE
US27 PGN browser enhancement

### DIFF
--- a/src/renderer/components/MenuBar.vue
+++ b/src/renderer/components/MenuBar.vue
@@ -140,7 +140,7 @@ export default {
 
         games = games.map((curVal, idx, arr) => {
           curVal.id = idx
-          curVal.supported = this.variantOptions.revGet(curVal.headers('Variant').toLowerCase()) !== undefined
+          curVal.supported = this.variantOptions.revGet(curVal.headers('Variant').toLowerCase()) !== undefined || !curVal.headers('Variant')
           return curVal
         })
 

--- a/src/renderer/components/MenuBar.vue
+++ b/src/renderer/components/MenuBar.vue
@@ -60,7 +60,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['viewAnalysis', 'initialized'])
+    ...mapGetters(['viewAnalysis', 'initialized', 'variantOptions'])
   },
   watch: {
     initialized: function () {
@@ -140,6 +140,7 @@ export default {
 
         games = games.map((curVal, idx, arr) => {
           curVal.id = idx
+          curVal.supported = this.variantOptions.revGet(curVal.headers('Variant').toLowerCase()) !== undefined
           return curVal
         })
 

--- a/src/renderer/components/MenuBar.vue
+++ b/src/renderer/components/MenuBar.vue
@@ -114,6 +114,8 @@ export default {
         // convert CRLF to LF
         data = data.replace(/\r\n/g, '\n')
 
+        let numOfUnparseableGames = 0
+
         let m
         while ((m = regex.exec(data)) !== null) {
           if (m.index === regex.lastIndex) {
@@ -125,11 +127,15 @@ export default {
             try {
               game = ffish.readGamePGN(match)
             } catch (error) {
-              alert('Could not parse PGN.')
+              numOfUnparseableGames = numOfUnparseableGames + 1
               return
             }
             games.push(game)
           })
+        }
+
+        if (numOfUnparseableGames !== 0) {
+          alert(numOfUnparseableGames + ' games could not be parsed.')
         }
 
         games = games.map((curVal, idx, arr) => {

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -91,6 +91,7 @@
 <script>
 import { remote } from 'electron'
 import { mapGetters } from 'vuex'
+import { bus } from '../main'
 
 export default {
   name: 'PgnBrowser',
@@ -100,7 +101,8 @@ export default {
       rounds: [],
       groupByRound: true,
       displayUnsupported: false,
-      menu: undefined
+      menu: undefined,
+      contextMenuEvents: undefined
     }
   },
   computed: {
@@ -144,15 +146,29 @@ export default {
     }
   },
   created: function () {
+    bus.$on('toggleGroup', (newVal) => {
+      this.groupByRound = newVal
+    })
+
+    bus.$on('toggleUnsupported', (newVal) => {
+      this.displayUnsupported = newVal
+    })
+
     const menuTemplate = [
       {
         label: 'Group by rounds',
         type: 'checkbox',
         checked: this.groupByRound,
         click: function (item, browserWindow, event) {
-          console.log('clicked option')
-          console.log(item.menu)
-          item.checked = this.groupByRound
+          bus.$emit('toggleGroup', item.checked)
+        }
+      },
+      {
+        label: 'Display unsupported',
+        type: 'checkbox',
+        checked: this.displayUnsupported,
+        click: function (item, browserWindow, event) {
+          bus.$emit('toggleUnsupported', item.checked)
         }
       }
     ]

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -57,7 +57,7 @@
               :key="game.id"
             >
               <div
-                v-if="game.headers('Round') === round.name && game.headers('Event') === round.eventName && (filterGameHeader('White', gameFilter, game) || filterGameHeader('Black', gameFilter, game)) && (displayUnsupported || game.supported)"
+                v-if="game.headers('Round') === round.name && game.headers('Event') === round.eventName && isGameVisible(game)"
                 class="browserelement gameoption"
                 :class="{ active : game === selectedGame, unsupported: !game.supported }"
                 @click="selectedGame = game"
@@ -74,7 +74,7 @@
           :key="game.id"
         >
           <div
-            v-if="(filterGameHeader('White', gameFilter, game) || filterGameHeader('Black', gameFilter, game)) && (displayUnsupported || game.supported)"
+            v-if="isGameVisible(game)"
             class="browserelement gameoption"
             :class="{ active : game === selectedGame }"
             @click="selectedGame = game"
@@ -141,11 +141,16 @@ export default {
     }
   },
   methods: {
-    filterGameHeader (key, searchString, game) {
-      return game.headers(key).toLowerCase().indexOf(searchString.toLowerCase()) !== -1
+    isGameVisible (game) {
+      if ((game.headers('White').toLowerCase().indexOf(this.gameFilter.toLowerCase()) !== -1 ||
+        game.headers('Black').toLowerCase().indexOf(this.gameFilter.toLowerCase()) !== -1) &&
+        (this.displayUnsupported || game.supported)) {
+        return true
+      } else {
+        return false
+      }
     }
   }
-
 }
 </script>
 

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -111,9 +111,6 @@ export default {
   watch: {
     loadedGames: function () {
       if (this.$store.getters.loadedGames) {
-        if (this.$store.getters.loadedGames.length <= 1) {
-          this.groupByRound = false
-        }
         // get distinct rounds
         this.rounds = this.$store.getters.loadedGames.map((value, idx, arr) => {
           return `${value.headers('Round')} ${value.headers('Event')}`

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -62,7 +62,7 @@
           <div
             v-if="isGameVisible(game)"
             class="browserelement gameoption"
-            :class="{ active : game === selectedGame }"
+            :class="{ active : game === selectedGame, unsupported: !game.supported }"
             @click="selectedGame = game"
           >
             {{ game ? game.headers("White") : 'unknown' }} <br> vs {{ game ? game.headers("Black") : 'unknown' }}

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -139,17 +139,9 @@ export default {
       this.displayUnsupported = newVal
     })
 
-    bus.$on('openAllRounds', () => {
-      this.rounds.forEach(round => {
-        round.visible = true
-      })
-    })
+    bus.$on('openAllRounds', () => this.setVisibilityOfAllRounds(true))
 
-    bus.$on('collapseAllRounds', () => {
-      this.rounds.forEach(round => {
-        round.visible = false
-      })
-    })
+    bus.$on('collapseAllRounds', () => this.setVisibilityOfAllRounds(false))
 
     const menuTemplate = [
       {
@@ -198,6 +190,11 @@ export default {
     },
     openContextMenu () {
       this.menu.popup(remote.getCurrentWindow())
+    },
+    setVisibilityOfAllRounds (value) {
+      this.rounds.forEach(round => {
+        round.visible = value
+      })
     }
   }
 }

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -1,25 +1,6 @@
 <template>
   <div>
     <div id="gameselect">
-      <i class="icon mdi mdi-cog-outline" @click="openContextMenu()" />
-      <input
-        id="groupcheckbox"
-        v-model="groupByRound"
-        type="checkbox"
-      >
-      <label
-        class="optionlabel"
-        for="groupcheckbox"
-      >Group by rounds?</label>
-      <input
-        id="displayunsupported"
-        v-model="displayUnsupported"
-        type="checkbox"
-      >
-      <label
-        class="optionlabel"
-        for="displayunsupported"
-      >Show unsupported?</label>
       <div class="search">
         <input
           id="gamefilter"
@@ -31,6 +12,10 @@
         <span
           slot="extra"
           class="icon mdi mdi-magnify"
+        />
+        <i
+          class="icon mdi mdi-cog-outline"
+          @click="openContextMenu()"
         />
       </div>
       <template v-if="groupByRound">
@@ -48,11 +33,11 @@
             <span
               slot="extra"
               class="icon mdi"
-              :class="[round.visible || gameFilter !== '' ? 'mdi-menu-up' : 'mdi-menu-down']"
+              :class="[round.visible ? 'mdi-menu-up' : 'mdi-menu-down']"
               style="float: right;"
             />
           </div>
-          <div v-show="round.visible || gameFilter !== ''">
+          <div v-show="round.visible">
             <div
               v-for="game in loadedGames"
               :key="game.id"
@@ -154,6 +139,18 @@ export default {
       this.displayUnsupported = newVal
     })
 
+    bus.$on('openAllRounds', () => {
+      this.rounds.forEach(round => {
+        round.visible = true
+      })
+    })
+
+    bus.$on('collapseAllRounds', () => {
+      this.rounds.forEach(round => {
+        round.visible = false
+      })
+    })
+
     const menuTemplate = [
       {
         label: 'Group by rounds',
@@ -169,6 +166,20 @@ export default {
         checked: this.displayUnsupported,
         click: function (item, browserWindow, event) {
           bus.$emit('toggleUnsupported', item.checked)
+        }
+      },
+      {
+        label: 'Open all rounds',
+        type: 'normal',
+        click: function () {
+          bus.$emit('openAllRounds')
+        }
+      },
+      {
+        label: 'Collapse all rounds',
+        type: 'normal',
+        click: function () {
+          bus.$emit('collapseAllRounds')
         }
       }
     ]
@@ -204,7 +215,7 @@ export default {
 }
 
 #gamefilter {
-  max-width: 80%;
+  max-width: 65%;
 }
 
 .roundseperator {
@@ -235,7 +246,6 @@ export default {
   padding: 0px 6px;
   margin: 0px 1px;
   border-radius: 3px;
-  float: right;
   background-color: #34495e;
   color: white;
 }
@@ -245,8 +255,14 @@ export default {
   cursor: pointer;
 }
 
+.icon.mdi-cog-outline:hover {
+  cursor: pointer;
+}
+
 .search {
   padding: 2px 0px;
+  white-space: nowrap;
+  width: 100%;
 }
 
 .unsupported {

--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <div id="gameselect">
+      <i class="icon mdi mdi-cog-outline" @click="openContextMenu()" />
       <input
         id="groupcheckbox"
         v-model="groupByRound"
@@ -88,6 +89,7 @@
 </template>
 
 <script>
+import { remote } from 'electron'
 import { mapGetters } from 'vuex'
 
 export default {
@@ -97,7 +99,8 @@ export default {
       gameFilter: '',
       rounds: [],
       groupByRound: true,
-      displayUnsupported: false
+      displayUnsupported: false,
+      menu: undefined
     }
   },
   computed: {
@@ -140,6 +143,22 @@ export default {
       }
     }
   },
+  created: function () {
+    const menuTemplate = [
+      {
+        label: 'Group by rounds',
+        type: 'checkbox',
+        checked: this.groupByRound,
+        click: function (item, browserWindow, event) {
+          console.log('clicked option')
+          console.log(item.menu)
+          item.checked = this.groupByRound
+        }
+      }
+    ]
+
+    this.menu = remote.Menu.buildFromTemplate(menuTemplate)
+  },
   methods: {
     isGameVisible (game) {
       if ((game.headers('White').toLowerCase().indexOf(this.gameFilter.toLowerCase()) !== -1 ||
@@ -149,6 +168,9 @@ export default {
       } else {
         return false
       }
+    },
+    openContextMenu () {
+      this.menu.popup(remote.getCurrentWindow())
     }
   }
 }

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -4,6 +4,9 @@ import App from './App'
 import router from './router'
 import { store } from './store'
 
+/* vue based event bus */
+export const bus = new Vue()
+
 if (!process.env.IS_WEB) Vue.use(require('vue-electron'))
 Vue.config.productionTip = false
 


### PR DESCRIPTION
## Purpose
This adds a small context menu to the PGN browser.

It also fixes #83 and fixes #129.
 
## Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
