### PR TITLE
Fix #135

### DIFF
--- a/src/renderer/components/ChessGround.vue
+++ b/src/renderer/components/ChessGround.vue
@@ -339,6 +339,10 @@ export default {
       premovable: {
         enabled: false
       },
+      events: {
+        select: () => this.removeFocusFromInputs(),
+        move: () => this.removeFocusFromInputs()
+      },
       orientation: this.orientation
     })
 
@@ -653,6 +657,11 @@ export default {
     drawShapes () {
       if (this.board !== null) {
         this.board.setAutoShapes([...this.shapes, ...this.pieceShapes])
+      }
+    },
+    removeFocusFromInputs () {
+      if (document.activeElement.nodeName.toLowerCase() === 'input') {
+        document.activeElement.blur()
       }
     }
   }

--- a/src/renderer/components/GameBoards.vue
+++ b/src/renderer/components/GameBoards.vue
@@ -121,21 +121,23 @@ export default {
   mounted () { // EventListener für Keyboardinput, ruft direkt die jeweilige Methode auf
     window.addEventListener('keydown', (event) => {
       const keyName = event.key
-      if (keyName === 'ArrowUp') {
-        event.preventDefault()
-        this.moveToStart()
-      }
-      if (keyName === 'ArrowDown') {
-        event.preventDefault()
-        this.moveToEnd()
-      }
-      if (keyName === 'ArrowLeft') {
-        event.preventDefault()
-        this.moveBackOne()
-      }
-      if (keyName === 'ArrowRight') {
-        event.preventDefault()
-        this.moveForwardOne()
+      if (event.target.nodeName.toLowerCase() !== 'input') {
+        if (keyName === 'ArrowUp') {
+          event.preventDefault()
+          this.moveToStart()
+        }
+        if (keyName === 'ArrowDown') {
+          event.preventDefault()
+          this.moveToEnd()
+        }
+        if (keyName === 'ArrowLeft') {
+          event.preventDefault()
+          this.moveBackOne()
+        }
+        if (keyName === 'ArrowRight') {
+          event.preventDefault()
+          this.moveForwardOne()
+        }
       }
     }, false)
   },


### PR DESCRIPTION
## Purpose
This should fix #135. I added a check so that the prevention of default behavior and navigation through the move history are only triggered when you aren't focusing an input.

## Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
