### PR TITLE
Fix missing # for some alternative check mates

### DIFF
--- a/src/renderer/components/MoveHistoryNode.vue
+++ b/src/renderer/components/MoveHistoryNode.vue
@@ -23,7 +23,7 @@
       :class="{ current : move.fen === fen }"
       @click="updateBoard(move)"
     >
-      {{ checkCheckmate(move.name) }}
+      {{ checkCheckmate(move).name }}
     </span>
     <span v-if="move.fen === mainFirstMove.fen">
       <MoveHistoryNode
@@ -66,6 +66,9 @@
 </template>
 
 <script>
+
+import ffish from 'ffish'
+
 export default {
   name: 'MoveHistoryNode',
   props: {
@@ -114,13 +117,14 @@ export default {
     updateBoard (move) {
       this.$store.dispatch('fen', this.move.fen)
     },
-    checkCheckmate (name) {
-      let last = this.$store.getters.mainFirstMove
-      while (last.main) {
-        last = last.main
-      }
-      if (this.$store.getters.legalMoves.length === 0 && name === last.name && !name.includes('#')) {
-        return name + '#'
+    checkCheckmate (moveIn) {
+      const move = moveIn
+      let name = moveIn.name
+      const variant = this.$store.getters.variant
+      const board = new ffish.Board(variant, move.fen)
+      const legalMoves = board.legalMoves
+      if (legalMoves.length === 0) {
+        name = name + '#'
       }
       return name
     }

--- a/src/renderer/components/MoveHistoryNode.vue
+++ b/src/renderer/components/MoveHistoryNode.vue
@@ -23,7 +23,7 @@
       :class="{ current : move.fen === fen }"
       @click="updateBoard(move)"
     >
-      {{ move.name }}
+      {{ checkCheckmate(move.name) }}
     </span>
     <span v-if="move.fen === mainFirstMove.fen">
       <MoveHistoryNode
@@ -113,6 +113,14 @@ export default {
   methods: {
     updateBoard (move) {
       this.$store.dispatch('fen', this.move.fen)
+    },
+    checkCheckmate (name) {
+      const moves = this.$store.getters.moves
+      const last = moves[moves.length - 1]
+      if (this.$store.getters.legalMoves.length === 0 && name === last.name) {
+        return name + '#'
+      }
+      return name
     }
   }
 }

--- a/src/renderer/components/MoveHistoryNode.vue
+++ b/src/renderer/components/MoveHistoryNode.vue
@@ -115,9 +115,11 @@ export default {
       this.$store.dispatch('fen', this.move.fen)
     },
     checkCheckmate (name) {
-      const moves = this.$store.getters.moves
-      const last = moves[moves.length - 1]
-      if (this.$store.getters.legalMoves.length === 0 && name === last.name) {
+      let last = this.$store.getters.mainFirstMove
+      while (last.main) {
+        last = last.main
+      }
+      if (this.$store.getters.legalMoves.length === 0 && name === last.name && !name.includes('#')) {
         return name + '#'
       }
       return name

--- a/src/renderer/components/MoveHistoryNode.vue
+++ b/src/renderer/components/MoveHistoryNode.vue
@@ -23,7 +23,7 @@
       :class="{ current : move.fen === fen }"
       @click="updateBoard(move)"
     >
-      {{ checkCheckmate(move).name }}
+      {{ checkCheckmate(move) }}
     </span>
     <span v-if="move.fen === mainFirstMove.fen">
       <MoveHistoryNode
@@ -122,8 +122,8 @@ export default {
       let name = moveIn.name
       const variant = this.$store.getters.variant
       const board = new ffish.Board(variant, move.fen)
-      const legalMoves = board.legalMoves
-      if (legalMoves.length === 0) {
+      const legalMoves = board.legalMoves()
+      if (legalMoves.length === 0 && !name.includes('#')) {
         name = name + '#'
       }
       return name


### PR DESCRIPTION
# Purpose
Now when the game is over with an "alternative" method (racingKings) a # is added to the winning move

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
