### PR TITLE
save Engine settings

### DIFF
--- a/src/renderer/components/EvalPlotButton.vue
+++ b/src/renderer/components/EvalPlotButton.vue
@@ -46,7 +46,7 @@ export default {
     plotDepth () {
       return this.$store.getters.evalPlotDepth
     }
-  } ,
+  },
   created () {
     document.addEventListener('finishedEval', () => {
       this.running = false

--- a/src/renderer/components/EvalPlotButton.vue
+++ b/src/renderer/components/EvalPlotButton.vue
@@ -11,7 +11,8 @@
         id="in"
         class="inputField"
         type="number"
-        :value="this.$store.getters.evalPlotDepth"
+        :value="plotDepth"
+        :placeholder="plotDepth"
         @change="updateEvalDepth"
       >
     </div>
@@ -41,6 +42,11 @@ export default {
       running: false
     }
   },
+  computed: {
+    plotDepth () {
+      return this.$store.getters.evalPlotDepth
+    }
+  } ,
   created () {
     document.addEventListener('finishedEval', () => {
       this.running = false

--- a/src/renderer/components/Mode960.vue
+++ b/src/renderer/components/Mode960.vue
@@ -172,6 +172,7 @@ input[type=number] {
 .inputField {
   width: 50px;
   background-color: var(--second-bg-color);
+  color: var(--main-text-color); 
 }
 .button {
   padding: 5px;

--- a/src/renderer/components/Mode960.vue
+++ b/src/renderer/components/Mode960.vue
@@ -172,7 +172,7 @@ input[type=number] {
 .inputField {
   width: 50px;
   background-color: var(--second-bg-color);
-  color: var(--main-text-color); 
+  color: var(--main-text-color);
 }
 .button {
   padding: 5px;

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -600,12 +600,16 @@ export const store = new Vuex.Store({
       }
     },
     initEngineOptions (context) {
-      context.dispatch('setEngineOptions', {
-        MultiPV: 5,
-        UCI_AnalyseMode: true,
-        UCI_Variant: context.getters.variant,
-        'Analysis Contempt': 'Off'
-      })
+      if(localStorage.getItem('engine' + context.state.activeEngine)){
+        context.dispatch('setEngineOptions', JSON.parse(localStorage.getItem('engine' + context.state.activeEngine)))
+      } else {
+        context.dispatch('setEngineOptions', {
+          MultiPV: 5,
+          UCI_AnalyseMode: true,
+          UCI_Variant: context.getters.variant,
+          'Analysis Contempt': 'Off'
+        })
+      }
     },
     setEngineOptions (context, payload) {
       if (context.getters.active) {
@@ -623,6 +627,7 @@ export const store = new Vuex.Store({
           engine.send(`setoption name ${name}`)
         }
       }
+      localStorage.setItem('engine' + context.state.activeEngine, JSON.stringify(context.state.engineSettings))
     },
     idName (context, payload) {
       context.commit('idName', payload)

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -426,7 +426,6 @@ export const store = new Vuex.Store({
     },
     evalPlotDepth (state, payload) {
       state.evalPlotDepth = payload
-      console.log('evalplotdepth commit')
       localStorage.evalPlotDepth = payload
     }
   },

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -426,6 +426,8 @@ export const store = new Vuex.Store({
     },
     evalPlotDepth (state, payload) {
       state.evalPlotDepth = payload
+      console.log('evalplotdepth commit')
+      localStorage.evalPlotDepth = payload
     }
   },
   actions: { // async
@@ -441,6 +443,9 @@ export const store = new Vuex.Store({
       context.dispatch('restartEngine')
     },
     initialize (context) {
+      if(localStorage.evalPlotDepth){
+        context.state.evalPlotDepth = localStorage.evalPlotDepth
+      }
       if (localStorage.darkMode) {
         if (localStorage.darkMode === 'true') {
           context.commit('switchDarkMode')

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -443,7 +443,7 @@ export const store = new Vuex.Store({
       context.dispatch('restartEngine')
     },
     initialize (context) {
-      if(localStorage.evalPlotDepth){
+      if (localStorage.evalPlotDepth) {
         context.state.evalPlotDepth = localStorage.evalPlotDepth
       }
       if (localStorage.darkMode) {
@@ -600,7 +600,7 @@ export const store = new Vuex.Store({
       }
     },
     initEngineOptions (context) {
-      if(localStorage.getItem('engine' + context.state.activeEngine)){
+      if (localStorage.getItem('engine' + context.state.activeEngine)) {
         context.dispatch('setEngineOptions', JSON.parse(localStorage.getItem('engine' + context.state.activeEngine)))
       } else {
         context.dispatch('setEngineOptions', {


### PR DESCRIPTION
# Purpose
Engine Settings are now  saved in localstorage ,
fixed some visiual bugs

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Starting the engine shows moves (test for both sides)
- [x] Engine Settings can be changed and are persistent with reloading the app

