### PR TITLE
Set UCI_Chess960 based on loaded board

### DIFF
--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -719,6 +719,7 @@ export const store = new Vuex.Store({
       }
       context.dispatch('fen', context.state.startFen)
       context.dispatch('updateBoard')
+      context.dispatch('setEngineOptions', { UCI_Chess960: false })
       context.commit('openedPGN', false)
     },
     increment (context, payload) {

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -101,7 +101,7 @@ function checkOption (options, name, value) {
   }
 }
 
-const filteredSettings = ['UCI_Variant']
+const filteredSettings = ['UCI_Variant', 'UCI_Chess960']
 
 export const store = new Vuex.Store({
   state: {
@@ -438,6 +438,7 @@ export const store = new Vuex.Store({
     resetBoard (context, payload) {
       context.commit('resetMultiPV')
       context.commit('resetBoard', payload)
+      context.dispatch('setEngineOptions', { UCI_Chess960: payload.is960 })
       context.dispatch('restartEngine')
     },
     initialize (context) {
@@ -573,6 +574,7 @@ export const store = new Vuex.Store({
         fen: payload.fen,
         is960: payload.is960
       })
+      context.dispatch('setEngineOptions', { UCI_Chess960: payload.is960 })
     },
     async engineBinary (context, payload) {
       const id = context.state.allEngines.findIndex(engine => engine.binary === payload)
@@ -599,7 +601,8 @@ export const store = new Vuex.Store({
         MultiPV: 5,
         UCI_AnalyseMode: true,
         UCI_Variant: context.getters.variant,
-        'Analysis Contempt': 'Off'
+        'Analysis Contempt': 'Off',
+        UCI_Chess960: context.state.board.is960()
       })
     },
     setEngineOptions (context, payload) {


### PR DESCRIPTION
## Purpose
UCI_Chess960 Engine setting is now set automatically and not by the user.

## Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
