### PR TITLE
Engine Stats now have an independent clock that updates every second

### DIFF
--- a/src/renderer/components/EngineStats.vue
+++ b/src/renderer/components/EngineStats.vue
@@ -51,7 +51,7 @@ export default {
       return {
         data: [
           ['Depth', 'node/s', 'Nodes', 'Time', 'Hash', 'TB'],
-          [g.depth + '/' + g.seldepth, this.parse(g.nps) + 'nps', this.parse(g.nodes), this.parseTime(g.time), g.hashfull, this.parse(g.tbhits)]
+          [g.depth + '/' + g.seldepth, this.parse(g.nps) + 'nps', this.parse(g.nodes), this.parseTime(g.enginetime), g.hashfull, this.parse(g.tbhits)]
         ],
         header: 'row',
         border: true,

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -154,6 +154,7 @@ export const store = new Vuex.Store({
       tbhits: 0,
       time: 0
     },
+    enginetime: 0,
     multipv: [
       {
         cp: 0,
@@ -190,7 +191,8 @@ export const store = new Vuex.Store({
     ],
     shogiVariants: [
       'shogi'
-    ]
+    ],
+    clock: null
   },
   mutations: { // sync
     curVar960Fen (state, payload) {
@@ -278,6 +280,7 @@ export const store = new Vuex.Store({
       state.engineStats = payload
     },
     resetEngineStats (state) {
+      state.enginetime = 0
       state.engineStats = {
         depth: 0,
         seldepth: 0,
@@ -441,6 +444,12 @@ export const store = new Vuex.Store({
     movesChangeDummy (state, payload) {
       state.moves = []
       state.moves = payload
+    },
+    setEngineClock (state) {
+      state.clock = setInterval(function () { state.enginetime = state.enginetime + 1000 }, 1000)
+    },
+    resetEngineTime (state) {
+      clearInterval(state.clock)
     }
   },
   actions: { // async
@@ -512,10 +521,12 @@ export const store = new Vuex.Store({
     },
     goEngine (context) {
       engine.send('go infinite')
+      context.commit('setEngineClock')
       context.commit('active', true)
     },
     stopEngine (context) {
       engine.send('stop')
+      context.commit('resetEngineTime')
       context.commit('active', false)
     },
     restartEngine (context) {
@@ -878,6 +889,9 @@ export const store = new Vuex.Store({
     },
     time (state) {
       return state.engineStats.time
+    },
+    enginetime (state) {
+      return state.enginetime
     },
     pv (state) {
       return state.multipv[0].pv


### PR DESCRIPTION
# Purpose
Engine stats have an independent clock

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
