### PR TITLE
jump button css fix 

### DIFF
--- a/src/renderer/components/JumpButtons.vue
+++ b/src/renderer/components/JumpButtons.vue
@@ -105,9 +105,6 @@ i {
   background-color: #2196F3;
   color: white;
 }
-.next {
-  color: black;
-}
 .round {
   border-radius: 90%;
 }


### PR DESCRIPTION
# Purpose
black buttons are now grey 

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
