### PR TITLE
PGN Games Key Navigation (n/p)

### DIFF
--- a/src/renderer/components/PgnBrowser.vue
+++ b/src/renderer/components/PgnBrowser.vue
@@ -124,6 +124,8 @@ export default {
           const event = value.substring(firstSpace + 1)
           return { name: round, eventName: event, visible: idx === 0 }
         })
+
+        this.$store.dispatch('rounds', this.rounds)
       }
     }
   },

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -168,6 +168,7 @@ export const store = new Vuex.Store({
     board: null,
     gameInfo: {},
     loadedGames: [],
+    rounds: null,
     selectedGame: null,
     boardStyle: 'blue',
     curVar960Fen: '',
@@ -414,6 +415,10 @@ export const store = new Vuex.Store({
     },
     loadedGames (state, payload) {
       state.loadedGames = payload
+      state.selectedGame = null
+    },
+    rounds (state, payload) {
+      state.rounds = payload
     },
     selectedGame (state, payload) {
       state.selectedGame = payload
@@ -861,6 +866,9 @@ export const store = new Vuex.Store({
     loadedGames (context, payload) {
       context.commit('loadedGames', payload)
     },
+    rounds (context, payload) {
+      context.commit('rounds', payload)
+    },
     async loadGame (context, payload) {
       context.commit('openedPGN', true)
       let variant = payload.game.headers('Variant').toLowerCase()
@@ -1111,6 +1119,9 @@ export const store = new Vuex.Store({
     },
     loadedGames (state) {
       return state.loadedGames
+    },
+    rounds (state) {
+      return state.rounds
     },
     selectedGame (state) {
       return state.selectedGame


### PR DESCRIPTION
* Added navigation keys to move through `pgn` games after a `pgn` file has been loaded
* If a pgn is loaded and `n` / `p` is pressed, the next / previous `pgn` game will be selected
* Immediatly after loading a `pgn`, no game has been selected yet. In this case, the first or last game will be selected instead
* Visually, if the next or pevious game has been played in a different `round`, this round will be expanded and the last round will be folded

-- If this folding behavior is not desired or different hotkeys shall be used, please comment and I will change it.
