### PR TITLE
Fixing Arrows on 9x10 boards - #223

### DIFF
--- a/src/renderer/components/ChessGround.vue
+++ b/src/renderer/components/ChessGround.vue
@@ -674,7 +674,6 @@ export default {
             },
         orientation: this.orientation
       })
-      console.log(this.board.state.lastMove)
       if (this.variant === 'crazyhouse' || this.variant === 'shogi') {
         this.updateHand()
       }


### PR DESCRIPTION
# Purpose
Fixing uncoordinated Arrows on 9x10 boards #223

Added a new function called extractMove for 9x10 boards instead of using the substring, to represent the 10th rank I used the char ':' (with conversions in and out where needed)

![image](https://user-images.githubusercontent.com/33104508/132867254-55c815eb-d269-4441-ad52-b5ae9a2fbe87.png)


