### PR TITLE
fix #272

### DIFF
--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -1314,12 +1314,8 @@ export const store = new Vuex.Store({
       // if the SAN in the pgn is the same than the SAN in states.moves
       // and we are at the last move, return pgn result
       if (state.selectedGame) {
-        let pgnBoard
-        if (state.selectedGame.headers('FEN')) {
-          pgnBoard = new ffish.Board(state.variant, state.selectedGame.headers('FEN'))
-        } else {
-          pgnBoard = state.board
-        }
+        let pgnBoard = new ffish.Board(state.variant, state.startFen)
+
         const pgnMoves = state.selectedGame.mainlineMoves()
         const san = pgnBoard.variationSan(pgnMoves, ffish.Notation.SAN, false)
         let str = ''
@@ -1334,10 +1330,8 @@ export const store = new Vuex.Store({
 
       if (typeof mate === 'number') {
         return `#${calcForSide(mate, state.turn)}`
-      } else if (currentMove && currentMove.name.includes('#')) {
-        return state.turn ? '0-1' : '1-0'
-      } else if (state.legalMoves.length === 0) {
-        return '1/2-1/2'
+      } else if (state.board != null && state.board.isGameOver()) {
+        return state.board.result()
       } else {
         return cpToString(getters.cpForWhite)
       }

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -1314,7 +1314,7 @@ export const store = new Vuex.Store({
       // if the SAN in the pgn is the same than the SAN in states.moves
       // and we are at the last move, return pgn result
       if (state.selectedGame) {
-        let pgnBoard = new ffish.Board(state.variant, state.startFen)
+        const pgnBoard = new ffish.Board(state.variant, state.startFen)
 
         const pgnMoves = state.selectedGame.mainlineMoves()
         const san = pgnBoard.variationSan(pgnMoves, ffish.Notation.SAN, false)


### PR DESCRIPTION
# Purpose
Fixes #272 by fixing two things in cpForWhiteStr:
1. Makes sure pgnBoard is set correctly.  Previously, it was setting it to the current board when there was no FEN header and setting it to the starting board when there was a FEN header.  Now, it always sets it to the starting FEN.
2. Fixes another issue where the result of the game was incorrectly shown.  In particular, the code was designed to be correct for standard chess, but was not correct for Horde.  It should now be correct for any variant since it is calling the methods of state.board.

# Pre-merge TODOs and Checks 
- [x] _(exclude checks that are not relevant for your feature)_
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
