### PR TITLE
Fix issue with dragging pieces in Crazyhouse

### DIFF
--- a/src/renderer/components/ChessGround.vue
+++ b/src/renderer/components/ChessGround.vue
@@ -646,8 +646,6 @@ export default {
     dropPiece (event, pieceType, color) {
       this.board.dragNewPiece({ role: pieceType, color: color, promoted: false }, event)
       this.selectedPiece = pieceType
-      console.log(`dropPiece: ${event} ${pieceType} ${color}`)
-      console.log(`dropPiece: ${this.board.getFen()}`)
     },
     extractMoves (move) {
       const letters = move.split(/(\d+)/)
@@ -828,7 +826,6 @@ export default {
           this.$store.dispatch('push', { move: uciMove, prev: prevMov })
           this.updateHand()
           this.afterMove()
-          console.log(this.turn)
         }
       }
     },

--- a/src/renderer/components/ChessPocket.vue
+++ b/src/renderer/components/ChessPocket.vue
@@ -66,8 +66,6 @@ export default {
       if (pieceCount === 0) {
         return
       }
-      console.log(`pieceType: ${pieceType}`)
-      console.log(`color: ${color}`)
       this.$emit('selection', event, pieceType, color)
     }
   }

--- a/src/renderer/components/ChessPocket.vue
+++ b/src/renderer/components/ChessPocket.vue
@@ -14,6 +14,7 @@
         class="piece"
         :class="[piece.type, color, piece.type === selectedPiece ? 'selected' : '' , orientation === 'white' && color === 'black' ? 'flipB' : '', orientation === 'black' ? 'flipW' : '']"
         @mousedown="clicked($event, piece.type, color, piece.count)"
+        @dragstart="(e) => e.preventDefault()"
       />
       <div
         class="piece-count noselect"


### PR DESCRIPTION
# Purpose
Fixes #254 by preventing default when starting to drag.  Don't ask me why this fixed it -- I have no idea.

I also removed a couple relevant console.log statements that were polluting the console.

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
