### PR TITLE
Crazyhouse fix and engine toggle fix

### DIFF
--- a/src/renderer/components/ChessGround.vue
+++ b/src/renderer/components/ChessGround.vue
@@ -646,8 +646,6 @@ export default {
     dropPiece (event, pieceType, color) {
       this.board.dragNewPiece({ role: pieceType, color: color, promoted: false }, event)
       this.selectedPiece = pieceType
-      console.log(`dropPiece: ${event} ${pieceType} ${color}`)
-      console.log(`dropPiece: ${this.board.getFen()}`)
     },
     extractMoves (move) {
       const letters = move.split(/(\d+)/)
@@ -828,7 +826,6 @@ export default {
           this.$store.dispatch('push', { move: uciMove, prev: prevMov })
           this.updateHand()
           this.afterMove()
-          console.log(this.turn)
         }
       }
     },

--- a/src/renderer/components/ChessPocket.vue
+++ b/src/renderer/components/ChessPocket.vue
@@ -66,8 +66,6 @@ export default {
       if (pieceCount === 0) {
         return
       }
-      console.log(`pieceType: ${pieceType}`)
-      console.log(`color: ${color}`)
       this.$emit('selection', event, pieceType, color)
     }
   }

--- a/src/renderer/components/ChessPocket.vue
+++ b/src/renderer/components/ChessPocket.vue
@@ -14,6 +14,7 @@
         class="piece"
         :class="[piece.type, color, piece.type === selectedPiece ? 'selected' : '' , orientation === 'white' && color === 'black' ? 'flipB' : '', orientation === 'black' ? 'flipW' : '']"
         @mousedown="clicked($event, piece.type, color, piece.count)"
+        @dragstart="(e) => e.preventDefault()"
       />
       <div
         class="piece-count noselect"

--- a/src/renderer/components/PVLines.vue
+++ b/src/renderer/components/PVLines.vue
@@ -151,28 +151,6 @@ export default {
       this.originalMultiPV = this.engineSettings.MultiPV
       this.updateLines()
     },
-    enginetime () {
-      if (this.active && this.PvE && !this.turn) {
-        if (this.PvEValue === 'time') {
-          if (this.enginetime >= this.PvEInput) {
-            if (this.lines[0] != null) {
-              this.onClick(this.lines[0])
-            }
-          }
-        } else if (this.PvEValue === 'nodes') {
-          if (this.enginetime === 60000) {
-            this.onClick(this.lines[0])
-          }
-        } else if (this.PvEValue === 'depth') {
-          if (this.enginetime === 60000) {
-            this.onClick(this.lines[0])
-          }
-          if (this.enginetime >= 5000 && this.depth === this.seldepth) {
-            this.onClick(this.lines[0])
-          }
-        }
-      }
-    },
     nodes () {
       if (this.active && this.PvE && !this.turn) {
         if (this.PvEValue === 'nodes') {

--- a/src/renderer/components/SettingsTab.vue
+++ b/src/renderer/components/SettingsTab.vue
@@ -258,7 +258,7 @@ export default {
           break
         case 'depth':
           this.$store.dispatch(
-            'setPvEParam', 
+            'setPvEParam',
             'go depth ' + this.PvEInput + ' movetime 60000')
           this.$store.dispatch('setPvEInput', this.PvEInput)
           break

--- a/src/renderer/components/SettingsTab.vue
+++ b/src/renderer/components/SettingsTab.vue
@@ -252,12 +252,14 @@ export default {
         case 'nodes':
           this.$store.dispatch(
             'setPvEParam',
-            'go nodes ' + this.PvEInput * 1000000
+            'go nodes ' + this.PvEInput * 1000000 + ' movetime 60000'
           )
           this.$store.dispatch('setPvEInput', this.PvEInput * 1000000)
           break
         case 'depth':
-          this.$store.dispatch('setPvEParam', 'go depth ' + this.PvEInput)
+          this.$store.dispatch(
+            'setPvEParam', 
+            'go depth ' + this.PvEInput + ' movetime 60000')
           this.$store.dispatch('setPvEInput', this.PvEInput)
           break
         default:

--- a/src/renderer/engine/driver.js
+++ b/src/renderer/engine/driver.js
@@ -26,7 +26,6 @@ export default class EngineDriver {
    */
   constructor (input, output) {
     this.events = new EventEmitter()
-    this.ignore = false
     this.ready = false
     this.pendingReady = false
     this.info = {
@@ -67,12 +66,6 @@ export default class EngineDriver {
   _parseLine (line) {
     this.events.emit('line', line)
     line = line.trim()
-    if (this.ignore) {
-      if (line.startsWith('bestmove')) {
-        this.ignore = false
-      }
-      return
-    }
     switch (line.split(/\s/)[0].trim()) {
       case 'uciok':
         this.events.emit('initialized')
@@ -122,6 +115,7 @@ export default class EngineDriver {
         break
       }
       case 'bestmove':
+        console.log('emit bestmove')
         const words = line.split(' ')
         const ucimove = words[1]
         this.events.emit('bestmove', ucimove)
@@ -160,7 +154,6 @@ export default class EngineDriver {
       case 'quit':
         return await this.quit()
       case 'stop':
-        this.ignore = true
         this._write(cmd)
         break
       case 'setoption':

--- a/src/renderer/engine/driver.js
+++ b/src/renderer/engine/driver.js
@@ -114,12 +114,12 @@ export default class EngineDriver {
         this.events.emit('info', info)
         break
       }
-      case 'bestmove':
-        console.log('emit bestmove')
+      case 'bestmove': {
         const words = line.split(' ')
         const ucimove = words[1]
         this.events.emit('bestmove', ucimove)
         break
+      }
     }
   }
 

--- a/src/renderer/engine/driver.js
+++ b/src/renderer/engine/driver.js
@@ -122,7 +122,9 @@ export default class EngineDriver {
         break
       }
       case 'bestmove':
-        this.events.emit('bestmove')
+        const words = line.split(' ')
+        const ucimove = words[1]
+        this.events.emit('bestmove', ucimove)
         break
     }
   }

--- a/src/renderer/engine/index.js
+++ b/src/renderer/engine/index.js
@@ -60,7 +60,7 @@ export class Engine extends EventEmitter {
 
       // run main engine
       this.mainWorker.postMessage({
-        payload: { binary, cwd, listeners: ['io', 'info'] },
+        payload: { binary, cwd, listeners: ['io', 'info', 'bestmove'] },
         type: 'run'
       })
 

--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -690,6 +690,12 @@ export const store = new Vuex.Store({
       engine.send(context.getters.PvEParam)
       context.commit('setEngineClock')
     },
+    PvEMakeMove (context, payload) {
+      const state = context.state
+      if (state.active && state.PvE && !state.turn) {
+        context.dispatch('push', { move: payload, prev: context.getters.currentMove[0] })
+      }
+    },
     setActiveTrue (context) {
       context.commit('active', true)
     },
@@ -1471,4 +1477,5 @@ ffish.onRuntimeInitialized = () => {
 
   // capture engine info
   engine.on('info', info => store.dispatch('updateMultiPV', info))
+  engine.on('bestmove', move => store.dispatch('PvEMakeMove', move))
 })()


### PR DESCRIPTION
# Purpose
Fixes #257 as described in my comment there.
Also fixes an issue with the engine toggle not always working.

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
