### PR TITLE
Fix issue with arrows not showing when MultiPV = 1

### DIFF
--- a/src/renderer/store.js
+++ b/src/renderer/store.js
@@ -1046,7 +1046,13 @@ export const store = new Vuex.Store({
               board.setFen(context.state.fen)
               console.warn('Invalid engine pv move.\nFEN:', board.fen(), '\nPV:', payload.pv)
             }
-            multipv[payload.multipv - 1] = pvline
+
+            // if there is only one pv
+            if (payload.multipv === undefined) {
+              multipv[0] = pvline
+            } else {
+              multipv[payload.multipv - 1] = pvline
+            }
           }
         }
         context.commit('multipv', multipv)


### PR DESCRIPTION
# Purpose
Fixes #236 

# Pre-merge TODOs and Checks 
- [x] PGN file loads correctly
- [x] Navigating through the move history works
- [x] Starting the engine shows moves (test for both sides)
- [x] Selecting a different variant loads a new board with the variant and you can make moves on the board
- [x] In Crazyhouse the pocket pieces are shown and you can drop pieces
