### PR TITLE
Update Fairy-SF download link

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -99,6 +99,6 @@ downloadBinary('multi-variant-stockfish', {
 })
 
 downloadBinary('fairy-stockfish', {
-  linux: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64',
-  win: 'https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64.exe'
+  linux: 'https://github.com/fairy-stockfish/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64',
+  win: 'https://github.com/fairy-stockfish/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64.exe'
 })


### PR DESCRIPTION
For me the automatic download of Fairy-SF on `npm install` failed
```
Downloading fairy-stockfish binary from https://github.com/ianfab/Fairy-Stockfish/releases/download/fairy_sf_13/fairy-stockfish-largeboard_x86-64...
Failed to download fairy-stockfish: Error: Server responded with a status of 301 (Moved Permanently)
```
There is a redirect to the new URL, but seems like it does not accept that, so the URL should be updated.

It perhaps also makes sense to use a newer Fairy-SF release, but for now I just fixed the link.